### PR TITLE
Link to build URL while waiting for status

### DIFF
--- a/cirrus_run/queries.py
+++ b/cirrus_run/queries.py
@@ -103,7 +103,7 @@ def wait_build(api, build_id: str, delay=3, abort=60*60):
     while time() < time_start + abort:
         response = api(query, params)
         status = response['build']['status']
-        log.info('build {}: {}'.format(build_id, status))
+        log.info('build https://cirrus-ci.com/build/{}: {}'.format(build_id, status))
         if status in {'COMPLETED'}:
             return True
         if status in {'CREATED', 'TRIGGERED', 'EXECUTING'}:


### PR DESCRIPTION
When watching a build in a gitlab job, seeing that the job is still executing in Cirrus is useful, but even more useful is having access to a clickable URL to jump from the gitlab job into the Cirrus job.